### PR TITLE
ci: add minimum GitHub token permissions for workflows

### DIFF
--- a/.github/workflows/auoms.yml
+++ b/.github/workflows/auoms.yml
@@ -2,6 +2,9 @@ name: auoms
 on:
   [workflow_dispatch]
    
+permissions:
+  contents: read
+
 jobs:
   run:
     name: Run

--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -2,8 +2,14 @@ name: Greetings
 
 on: [pull_request_target, issues, workflow_dispatch]
 
+permissions:
+  contents: read
+
 jobs:
   greeting:
+    permissions:
+      issues: write  # for actions/first-interaction to comment on first issue
+      pull-requests: write  # for actions/first-interaction to comment on first PR
     runs-on: ubuntu-latest
     
     steps:

--- a/.github/workflows/greetings1.yml
+++ b/.github/workflows/greetings1.yml
@@ -2,6 +2,9 @@ name: Greetings
 
 on: [pull_request_target, issues]
 
+permissions:
+  contents: read
+
 jobs:
   greeting:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,6 +3,9 @@ on:
   release:
     types: [created]
     
+permissions:
+  contents: read
+
 jobs:
   publish-npm:
     runs-on: ubuntu-latest  


### PR DESCRIPTION
### Description
This PR adds minimum token permissions for the GITHUB_TOKEN in GitHub Actions workflows using [secure-workflows](https://github.com/step-security/secure-workflows).

The GitHub Actions workflow has a GITHUB_TOKEN with write access to multiple scopes. Here is an example of the permissions in one of the workflow runs:
https://app.stepsecurity.io

After this change, the scopes will be reduced to the minimum needed for the following workflows:

- auoms.yml
- greetings.yml
- greetings1.yml
- main.yml


### Motivation and Context

- This is a security best practice, so if the GITHUB_TOKEN is compromised due to a vulnerability or compromised Action, the damage will be reduced.
- [GitHub recommends](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token) defining minimum GITHUB_TOKEN permissions.
- The Open Source Security Foundation (OpenSSF) [Scorecards](https://github.com/ossf/scorecard) also treats not setting token permissions as a high-risk issue. This change will help increase the Scorecard score for this repository.

Signed-off-by: Ashish Kurmi <akurmi@stepsecurity.io>